### PR TITLE
add Potential Uplifts tab with Nightly and Beta lists

### DIFF
--- a/app/bugdash.mjs
+++ b/app/bugdash.mjs
@@ -12,6 +12,7 @@ import * as REO from "tabs/reo";
 import * as Stalled from "tabs/stalled";
 import * as Tracked from "tabs/tracked";
 import * as Triage from "tabs/triage";
+import * as Uplift from "tabs/uplift";
 import * as Tooltips from "tooltips";
 import { _ } from "util";
 
@@ -34,6 +35,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     REO.initUI();
     Tracked.initUI();
     Beta.initUI();
+    Uplift.initUI();
     Overview.initUI();
     Tooltips.initUI();
 

--- a/app/buglist.mjs
+++ b/app/buglist.mjs
@@ -136,6 +136,7 @@ export function append({
     description,
     query,
     include,
+    fetchBugs,
     template,
     augment,
     order,
@@ -162,6 +163,7 @@ export function append({
         $root: $root,
         query: query,
         includeFn: include,
+        fetchBugs: fetchBugs,
         $timestampTemplate: _(`#bug-row-timestamp-${template || "creation"}`),
         augmentFn: augment,
         order: "default",
@@ -257,7 +259,9 @@ export async function refresh(id) {
     // execute query
     let response;
     try {
-        response = await Bugzilla.rest(buglist.url);
+        response = buglist.fetchBugs
+            ? await buglist.fetchBugs(buglist)
+            : await Bugzilla.rest(buglist.url);
     } catch (_error) {
         setErrorState(buglist);
         return;

--- a/app/buglists/uplift.mjs
+++ b/app/buglists/uplift.mjs
@@ -1,0 +1,102 @@
+import * as BugList from "buglist";
+import * as Bugzilla from "bugzilla";
+import * as Global from "global";
+
+const FLOOR_VERSION = 5;
+const AFFECTING_VALUES = "affected,fix-optional,?";
+const CHUNK_SIZE = 40;
+
+function buildAnchor(anchorVersion) {
+    return {
+        resolution: ["---", "FIXED"],
+        f1: `cf_status_firefox${anchorVersion}`,
+        o1: "anyexact",
+        v1: "fixed,verified",
+    };
+}
+
+function buildChunkQuery(anchorVersion, startVersion, endVersion) {
+    const query = {
+        ...buildAnchor(anchorVersion),
+        f2: "OP",
+        j2: "OR",
+    };
+    let idx = 3;
+    for (let v = startVersion; v < endVersion; v++) {
+        query[`f${idx}`] = `cf_status_firefox${v}`;
+        query[`o${idx}`] = "anyexact";
+        query[`v${idx}`] = AFFECTING_VALUES;
+        idx++;
+    }
+    query[`f${idx}`] = "CP";
+    return query;
+}
+
+function appendUpliftList({
+    $container,
+    usesComponents,
+    channel,
+    channelTitle,
+    anchorVersion,
+}) {
+    BugList.append({
+        id: `uplift-${channel}-affecting-prior`,
+        $container: $container,
+        title: `${anchorVersion} (${channelTitle}) Fixed, Affecting Prior Versions`,
+        description:
+            "Candidates for uplift/backport consideration.\n" +
+            "Bugs with all of the following:\n" +
+            `- status-firefox${anchorVersion} set to fixed or verified\n` +
+            `- any status-firefox${FLOOR_VERSION}..${anchorVersion - 1} set to ` +
+            "affected, fix-optional, or ?\n" +
+            "Bugs are ordered by creation date, oldest first.",
+        query: buildAnchor(anchorVersion),
+        usesComponents: usesComponents,
+        fetchBugs: async (buglist) => {
+            const components = buglist.usesComponents
+                ? Global.selectedComponents()
+                : undefined;
+            const urls = [];
+            for (
+                let start = FLOOR_VERSION;
+                start < anchorVersion;
+                start += CHUNK_SIZE
+            ) {
+                const end = Math.min(start + CHUNK_SIZE, anchorVersion);
+                urls.push(
+                    Bugzilla.queryURL(
+                        buildChunkQuery(anchorVersion, start, end),
+                        components,
+                    ),
+                );
+            }
+            const responses = await Promise.all(urls.map((url) => Bugzilla.rest(url)));
+            const byId = new Map();
+            for (const response of responses) {
+                for (const bug of response.bugs) {
+                    byId.set(bug.id, bug);
+                }
+            }
+            return { bugs: Array.from(byId.values()) };
+        },
+    });
+}
+
+export function init($container, usesComponents) {
+    const releases = Global.releaseData();
+    const channels = [
+        {
+            channel: "nightly",
+            channelTitle: "Nightly",
+            anchorVersion: Number(releases.nightly.version),
+        },
+        {
+            channel: "beta",
+            channelTitle: "Beta",
+            anchorVersion: Number(releases.beta.version),
+        },
+    ];
+    for (const c of channels) {
+        appendUpliftList({ $container, usesComponents, ...c });
+    }
+}

--- a/app/tabs.mjs
+++ b/app/tabs.mjs
@@ -76,6 +76,10 @@ function addTabs() {
             name: "beta",
             title: "Beta",
         },
+        {
+            name: "uplift",
+            title: "Potential Uplifts",
+        },
     ]);
 }
 

--- a/app/tabs/uplift.mjs
+++ b/app/tabs/uplift.mjs
@@ -1,0 +1,10 @@
+import * as BugList from "buglist";
+import * as Uplift from "buglists/uplift";
+import { _ } from "util";
+
+export function initUI() {
+    const $content = _("#uplift-content");
+
+    const $group = BugList.newGroup($content);
+    Uplift.init($group, false);
+}

--- a/index.html
+++ b/index.html
@@ -37,8 +37,8 @@
     <script type="importmap">
     {
       "imports": {
-        "bugdash": "./app/bugdash.mjs?3c86a2fd7435ff05ce0576cd3ab28183",
-        "buglist": "./app/buglist.mjs?be1b03a8cc991c34de6a1a9dcd289bc1",
+        "bugdash": "./app/bugdash.mjs?f66a9944505dcfd6bd24032d1455d4d9",
+        "buglist": "./app/buglist.mjs?27b39b284181b753149621a56a9afc2d",
         "buglists/assigned-inactive": "./app/buglists/assigned-inactive.mjs?b67a90e725c212c02980ca7c8581275a",
         "buglists/beta": "./app/buglists/beta.mjs?c6ef7768c95f7273ed2ad3b73a593802",
         "buglists/blockers": "./app/buglists/blockers.mjs?f6e798f0359994ed20a373149cb49798",
@@ -60,12 +60,13 @@
         "buglists/topcrashers": "./app/buglists/topcrashers.mjs?b747f1889a13ac5127212473cf75fc78",
         "buglists/tracked": "./app/buglists/tracked.mjs?47a696d9df9ad3ece6f367fb61e9c6e8",
         "buglists/triage-needed": "./app/buglists/triage-needed.mjs?8e466c0f07b94bf9220da43c38e4e5a1",
+        "buglists/uplift": "./app/buglists/uplift.mjs?2a51285affa408b65358ca4648080791",
         "bugtable": "./app/bugtable.mjs?128cb6524e5d0568dcd5f4d646cec2b9",
         "bugzilla": "./app/bugzilla.mjs?19d143e25cc1a67f89963ad8556ba46c",
         "dialog": "./app/dialog.mjs?8c2b0b6af0aa3d362f724856cba39482",
         "global": "./app/global.mjs?fbdd7e766cf89a39067950550f24f04d",
         "menus": "./app/menus.mjs?f766e80f5362fc3c647559fac6755822",
-        "tabs": "./app/tabs.mjs?9741b2d11b9fa118cad5e73be9b4ef3c",
+        "tabs": "./app/tabs.mjs?3a2f04d0a68262d72ec147ee9b5b8424",
         "tabs/beta": "./app/tabs/beta.mjs?590b7c9936790717155c21da70f37222",
         "tabs/components": "./app/tabs/components.mjs?91527e62099e894ee6915c6794ea505b",
         "tabs/help": "./app/tabs/help.mjs?61201f8aedc7ee3a1827b596237a9466",
@@ -75,6 +76,7 @@
         "tabs/stalled": "./app/tabs/stalled.mjs?35ad2cb4ab092aef77c455daca511acb",
         "tabs/tracked": "./app/tabs/tracked.mjs?f416cd08cf5dc3101d75d0ccbd41a05f",
         "tabs/triage": "./app/tabs/triage.mjs?deb37c0fc8702feee793c3d776fae4f2",
+        "tabs/uplift": "./app/tabs/uplift.mjs?57811cefd847541feb2a985c0be5229c",
         "tooltips": "./app/tooltips.mjs?f6ce915e9ef0058cae9ecc157ad8a1a9",
         "util": "./app/util.mjs?089b50bcc248dc22a5f40620a72f4ac0"
       }
@@ -576,6 +578,6 @@
 
     <script src="assets/popperjs-2.11.7.min.js"></script>
     <script src="assets/tippyjs-6.3.7.min.js"></script>
-    <script type="module" src="app/bugdash.mjs?3c86a2fd7435ff05ce0576cd3ab28183"></script>
+    <script type="module" src="app/bugdash.mjs?f66a9944505dcfd6bd24032d1455d4d9"></script>
   </body>
 </html>


### PR DESCRIPTION
Each list surfaces bugs fixed/verified in the anchor channel that are still flagged affected, fix-optional, or ? on any prior Firefox version down to 5 — candidates for uplift/backport.

Splits the search across multiple smaller OR-chunked queries (~40 versions each) and merges results client-side, working around Bugzilla query complexity limits that prevent spanning all versions in one request.

Adds a fetchBugs hook to BugList.append() for lists that need to load from multiple requests.