### PR TITLE
Add per-bug 'Triage with bugbug' button (frontend-scoped, beta)

### DIFF
--- a/app/buglist.css
+++ b/app/buglist.css
@@ -194,6 +194,21 @@
     color: #9248c8;
 }
 
+.bug-row .bug-icons a.triage-btn,
+.bug-row .bug-icons a.triage-btn:visited {
+    color: #777;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.bug-row .bug-icons a.triage-btn span {
+    cursor: pointer;
+}
+
+.bug-row .bug-icons a.triage-btn:hover {
+    color: #008080;
+}
+
 .buglist tr.odd {
     background: #fff;
 }

--- a/app/buglist.css
+++ b/app/buglist.css
@@ -194,19 +194,25 @@
     color: #9248c8;
 }
 
-.bug-row .bug-icons a.triage-btn,
-.bug-row .bug-icons a.triage-btn:visited {
-    color: #777;
+.bug-row .timestamp a.triage-btn,
+.bug-row .timestamp a.triage-btn:visited {
+    display: block;
+    width: fit-content;
+    padding: 2px 6px;
+    margin: 0 0 4px auto;
+    font-size: 11px;
+    font-weight: normal;
+    color: #28292a;
+    white-space: nowrap;
     text-decoration: none;
     cursor: pointer;
+    border: 1px solid silver;
+    border-radius: 2px;
 }
 
-.bug-row .bug-icons a.triage-btn span {
-    cursor: pointer;
-}
-
-.bug-row .bug-icons a.triage-btn:hover {
+.bug-row .timestamp a.triage-btn:hover {
     color: #008080;
+    background: #ebebeb;
 }
 
 .buglist tr.odd {

--- a/app/buglist.mjs
+++ b/app/buglist.mjs
@@ -18,6 +18,40 @@ import {
 
 const TRIAGE_URL = "https://hackbot-ui-xxesjlbeoa-uc.a.run.app";
 
+// Components in scope for bugbug's frontend-triage agent (Firefox desktop
+// frontend). Keyed as "Product::Component". Update if the agent broadens scope.
+const FRONTEND_TRIAGE_COMPONENTS = new Set([
+    // Firefox product
+    "Firefox::Address Bar",
+    "Firefox::Bookmarks & History",
+    "Firefox::General",
+    "Firefox::Menus",
+    "Firefox::New Tab Page",
+    "Firefox::Session Restore",
+    "Firefox::Sidebar",
+    "Firefox::Tabbed Browser",
+    "Firefox::Tabbed Browser: Split View",
+    "Firefox::Tabbed Browser: Tab Groups",
+    "Firefox::Theme",
+    "Firefox::Toolbars and Customization",
+    // Toolkit product (shared frontend UI / built-in pages)
+    "Toolkit::Alerts Service",
+    "Toolkit::Content Prompts",
+    "Toolkit::Error Pages",
+    "Toolkit::Find Toolbar",
+    "Toolkit::General",
+    "Toolkit::Picture-in-Picture",
+    "Toolkit::Popup Blocker",
+    "Toolkit::PopupNotifications and Notification Bars",
+    "Toolkit::Preferences",
+    "Toolkit::Printing",
+    "Toolkit::Reader Mode",
+    "Toolkit::Themes",
+    "Toolkit::Toolbars and Toolbar Customization",
+    "Toolkit::UI Widgets",
+    "Toolkit::Video/Audio Controls",
+]);
+
 const g = {
     buglists: {},
 };
@@ -156,6 +190,7 @@ export function append({
     counterGuidelines,
     beforeRefresh,
     urlsBuilder,
+    triageAgent,
 } = {}) {
     const $root = cloneTemplate(_("#buglist-template")).querySelector(
         ".buglist-container",
@@ -185,6 +220,7 @@ export function append({
         counterGuidelines: counterGuidelines,
         beforeRefresh: beforeRefresh,
         urlsBuilder: urlsBuilder || _defaultUrlsBuilder,
+        triageAgent: triageAgent,
     };
     if (lazyLoad) {
         $root.classList.add("lazy");
@@ -319,7 +355,12 @@ export async function refresh(id) {
     let bugs = [];
     for (const bug of responseBugs) {
         bug.url = `https://bugzilla.mozilla.org/show_bug.cgi?id=${bug.id}`;
-        bug.triage_url = `${TRIAGE_URL}/?agent=frontend-triage&bug_id=${bug.id}`;
+        bug.showTriage =
+            buglist.triageAgent &&
+            FRONTEND_TRIAGE_COMPONENTS.has(`${bug.product}::${bug.component}`);
+        bug.triage_url = bug.showTriage
+            ? `${TRIAGE_URL}/?agent=frontend-triage&bug_id=${bug.id}`
+            : "";
         bug.severity_title = severityTitles[bug.severity] || "";
         bug.creation_epoch = Date.parse(bug.creation_time);
         bug.creation_ago = timeAgo(bug.creation_epoch);
@@ -545,6 +586,9 @@ export async function refresh(id) {
             // main row
             const $row = cloneTemplate($template);
             updateTemplate($row, bug);
+            if (!bug.showTriage) {
+                _($row, ".triage-btn")?.remove();
+            }
             // replace the timestamp cell
             const $timestamp = cloneTemplate(buglist.$timestampTemplate);
             updateTemplate($timestamp, bug);

--- a/app/buglist.mjs
+++ b/app/buglist.mjs
@@ -16,6 +16,8 @@ import {
 
 /* global tippy */
 
+const TRIAGE_URL = "https://hackbot-ui-xxesjlbeoa-uc.a.run.app";
+
 const g = {
     buglists: {},
 };
@@ -317,6 +319,7 @@ export async function refresh(id) {
     let bugs = [];
     for (const bug of responseBugs) {
         bug.url = `https://bugzilla.mozilla.org/show_bug.cgi?id=${bug.id}`;
+        bug.triage_url = `${TRIAGE_URL}/?agent=frontend-triage&bug_id=${bug.id}`;
         bug.severity_title = severityTitles[bug.severity] || "";
         bug.creation_epoch = Date.parse(bug.creation_time);
         bug.creation_ago = timeAgo(bug.creation_epoch);

--- a/app/buglists/triage-needed.mjs
+++ b/app/buglists/triage-needed.mjs
@@ -31,5 +31,6 @@ export function init($container) {
             v4: "meta",
         },
         usesComponents: true,
+        triageAgent: true,
     });
 }

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       type="text/css"
       href="app/tabs/help.css?c85e68301e2f59a3727b7f4884e85d71"
     >
-    <link rel="stylesheet" type="text/css" href="app/buglist.css?8c8a1dc0a351bf829f31ae3c92c3efc7">
+    <link rel="stylesheet" type="text/css" href="app/buglist.css?abc18fed0d59f8d9df0336e9d02c9e76">
     <link rel="stylesheet" type="text/css" href="app/bugtable.css?5d4ebc21b4656580d6e28319d737ebe3">
     <link rel="stylesheet" type="text/css" href="app/dialog.css?ac7e56024618ca7d27da454c08c7b17e">
     <link rel="stylesheet" type="text/css" href="app/tooltips.css?96325cf63a17b57c482ef97289322845">
@@ -38,7 +38,7 @@
     {
       "imports": {
         "bugdash": "./app/bugdash.mjs?3c86a2fd7435ff05ce0576cd3ab28183",
-        "buglist": "./app/buglist.mjs?36663676566fd3c7b6f0cc24773fc982",
+        "buglist": "./app/buglist.mjs?92470261c0679c3fa5fa3938a63c099d",
         "buglists/assigned-inactive": "./app/buglists/assigned-inactive.mjs?b67a90e725c212c02980ca7c8581275a",
         "buglists/beta": "./app/buglists/beta.mjs?c6ef7768c95f7273ed2ad3b73a593802",
         "buglists/blockers": "./app/buglists/blockers.mjs?f6e798f0359994ed20a373149cb49798",
@@ -59,7 +59,7 @@
         "buglists/stalled": "./app/buglists/stalled.mjs?da2d4f814ac5b70c90a3ebb32f3b23e6",
         "buglists/topcrashers": "./app/buglists/topcrashers.mjs?b747f1889a13ac5127212473cf75fc78",
         "buglists/tracked": "./app/buglists/tracked.mjs?47a696d9df9ad3ece6f367fb61e9c6e8",
-        "buglists/triage-needed": "./app/buglists/triage-needed.mjs?2ab63b30b4e8a29a2400208f0b795744",
+        "buglists/triage-needed": "./app/buglists/triage-needed.mjs?d7217499b2cc51876a36b2a6b4aebf29",
         "buglists/uplift-candidates": "./app/buglists/uplift-candidates.mjs?cf1a47416d688b915c2fdb94eb817c02",
         "bugtable": "./app/bugtable.mjs?128cb6524e5d0568dcd5f4d646cec2b9",
         "bugzilla": "./app/bugzilla.mjs?19d143e25cc1a67f89963ad8556ba46c",
@@ -329,16 +329,7 @@
             class="needinfo"
             data-title-field="needinfo_target"
             data-field="needinfo_icon"
-          ></span><span class="groups" data-title-field="groups" data-field="groups_icon"></span
-          ><a
-            href="#"
-            class="triage-btn"
-            data-href-field="triage_url"
-            target="_blank"
-            title="Use bugbug to run the triage investigation for this bug"
-            aria-label="Use bugbug to run the triage investigation for this bug"
-            ><span aria-hidden="true">manage_search</span></a
-          >
+          ></span><span class="groups" data-title-field="groups" data-field="groups_icon"></span>
         </td>
         <td class="severity" data-title-field="severity_title" data-field="severity"></td>
         <td class="priority" data-title-field="priority_title" data-field="priority"></td>
@@ -349,7 +340,16 @@
         <td class="reporter" data-field="creator_nick" data-title-field="creator_name"></td>
         <td class="owner" data-field="assigned_to_nick" data-title-field="assigned_to_name"></td>
         <td class="keywords" data-html="keywords_html" data-title-field="keywords_title"></td>
-        <td class="timestamp"></td>
+        <td class="timestamp">
+          <a
+            href="#"
+            class="triage-btn"
+            data-href-field="triage_url"
+            target="_blank"
+            title="Use bugbug to run the triage investigation for this bug (in development)"
+            >Beta · Triage with bugbug</a
+          >
+        </td>
       </tr>
     </template>
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       type="text/css"
       href="app/tabs/help.css?c85e68301e2f59a3727b7f4884e85d71"
     >
-    <link rel="stylesheet" type="text/css" href="app/buglist.css?891552c0f470b4c59dc67f942d33b057">
+    <link rel="stylesheet" type="text/css" href="app/buglist.css?8c8a1dc0a351bf829f31ae3c92c3efc7">
     <link rel="stylesheet" type="text/css" href="app/bugtable.css?5d4ebc21b4656580d6e28319d737ebe3">
     <link rel="stylesheet" type="text/css" href="app/dialog.css?ac7e56024618ca7d27da454c08c7b17e">
     <link rel="stylesheet" type="text/css" href="app/tooltips.css?96325cf63a17b57c482ef97289322845">
@@ -38,7 +38,7 @@
     {
       "imports": {
         "bugdash": "./app/bugdash.mjs?3c86a2fd7435ff05ce0576cd3ab28183",
-        "buglist": "./app/buglist.mjs?b050504769a184ee20c0ba8c4872acbb",
+        "buglist": "./app/buglist.mjs?36663676566fd3c7b6f0cc24773fc982",
         "buglists/assigned-inactive": "./app/buglists/assigned-inactive.mjs?b67a90e725c212c02980ca7c8581275a",
         "buglists/beta": "./app/buglists/beta.mjs?c6ef7768c95f7273ed2ad3b73a593802",
         "buglists/blockers": "./app/buglists/blockers.mjs?f6e798f0359994ed20a373149cb49798",
@@ -329,7 +329,16 @@
             class="needinfo"
             data-title-field="needinfo_target"
             data-field="needinfo_icon"
-          ></span><span class="groups" data-title-field="groups" data-field="groups_icon"></span>
+          ></span><span class="groups" data-title-field="groups" data-field="groups_icon"></span
+          ><a
+            href="#"
+            class="triage-btn"
+            data-href-field="triage_url"
+            target="_blank"
+            title="Use bugbug to run the triage investigation for this bug"
+            aria-label="Use bugbug to run the triage investigation for this bug"
+            ><span aria-hidden="true">manage_search</span></a
+          >
         </td>
         <td class="severity" data-title-field="severity_title" data-field="severity"></td>
         <td class="priority" data-title-field="priority_title" data-field="priority"></td>


### PR DESCRIPTION
Reworks the per-bug triage link from #51 to address @globau's review feedback. (Reopening #51 wasn't possible, so this is a fresh PR from the same branch.)

Adds a per-bug button that opens bugbug's `frontend-triage` console in a new tab, now scoped and restyled per the feedback on #51.

### Feedback addressed
- **"Linking to a demo/pre-alpha site isn't stable."** The button is labeled **"Beta · Triage with bugbug"** so users know the destination is still in development.
- **"Shouldn't be on every bug/every list."** A new per-buglist `triageAgent` flag gates it; only the **Triage Decision Needed** list opts in.
- **"Must be restricted to Frontend-team components."** Rendered only for a curated Firefox/Toolkit `Product::Component` allowlist matching the agent's documented scope. (BMO's `team_name` field alone doesn't work — e.g. Tabbed Browser, Address Bar, and Theme are team "Search Next Generation" and New Tab Page is its own team, yet the agent explicitly triages all of them.)
- **"Wrong icon/spot; move it right, above the timestamp, styled as a button."** Removed the `manage_search` glyph from the status-icon cell; the button now sits on the right above each bug's timestamp, styled as a button.

### Files
- `app/buglist.mjs` — `FRONTEND_TRIAGE_COMPONENTS` allowlist, `triageAgent` config option, per-bug gating (`bug.showTriage`), remove the button element when out of scope
- `app/buglists/triage-needed.mjs` — opt in with `triageAgent: true`
- `index.html` — move the anchor to the `.timestamp` cell; label "Beta · Triage with bugbug"
- `app/buglist.css` — button styling on the right