### PR TITLE
REO page changes

### DIFF
--- a/app/buglists/reo.mjs
+++ b/app/buglists/reo.mjs
@@ -7,10 +7,24 @@ import * as Global from "global";
 const g = {
     // teams selected in the Regressions page team filter; empty = no filtering
     teams: new Set(),
+    // quick filters selected in the Regressions page filter bar; when any are
+    // active a bug is kept if it matches ANY of them (OR). All false = no
+    // filtering.
+    filters: {
+        severityHigh: false,
+        missingSeverity: false,
+        unassigned: false,
+        missingRegressor: false,
+        withoutNeedinfo: false,
+    },
 };
 
 export function setTeams(teams) {
     g.teams = new Set(teams);
+}
+
+export function setFilters(next) {
+    Object.assign(g.filters, next);
 }
 
 function maxFieldNumber(query) {
@@ -93,9 +107,49 @@ function appendTeamFilter(query) {
     query[`f${n}`] = "CP"; // close team OR group
 }
 
+// Append the active quick filters as a single top-level AND clause containing
+// an OR group.
+function appendQuickFilters(query) {
+    const clauses = [];
+    if (g.filters.severityHigh) {
+        clauses.push(["bug_severity", "anyexact", "S1,S2"]);
+    }
+    if (g.filters.missingSeverity) {
+        clauses.push(["bug_severity", "anyexact", "--"]);
+    }
+    if (g.filters.unassigned) {
+        clauses.push(["assigned_to", "equals", "nobody@mozilla.org"]);
+    }
+    if (g.filters.missingRegressor) {
+        clauses.push(["regressed_by", "isempty", ""]);
+    }
+    if (g.filters.withoutNeedinfo) {
+        clauses.push(["flagtypes.name", "notsubstring", "needinfo"]);
+    }
+    if (clauses.length === 0) {
+        return;
+    }
+
+    let n = maxFieldNumber(query) + 1;
+    query[`f${n}`] = "OP";
+    query[`j${n}`] = "OR";
+    n++;
+    for (const [field, op, value] of clauses) {
+        query[`f${n}`] = field;
+        query[`o${n}`] = op;
+        query[`v${n}`] = value;
+        n++;
+    }
+    query[`f${n}`] = "CP";
+}
+
+// The team and quick filters are injected as independent top-level AND clauses.
+// Each computes its field offset from the current max f#, so they chain without
+// collision.
 function reoUrlsBuilder(buglist) {
     const query = { ...buglist.query };
     appendTeamFilter(query);
+    appendQuickFilters(query);
     return [Bugzilla.queryURL(query)];
 }
 

--- a/app/buglists/reo.mjs
+++ b/app/buglists/reo.mjs
@@ -13,7 +13,6 @@ export function init($container, ver) {
             `- status-firefox${ver.nightly} set to affected\n` +
             `- status-firefox${ver.beta} set to any of unaffected ? ---\n` +
             "Bugs with any of the following are ignored:\n" +
-            "- open NEEDINFO request\n" +
             `- tracking-firefox${ver.nightly} is -\n` +
             "- stalled or intermittent-failure keywords\n" +
             "- within the Testing product\n" +
@@ -44,9 +43,6 @@ export function init($container, ver) {
             o5: "equals",
             v5: "---",
             f6: "CP",
-            f7: "flagtypes.name",
-            o7: "notsubstring",
-            v7: "needinfo",
             f8: `cf_tracking_firefox${ver.nightly}`,
             o8: "notequals",
             v8: "-",
@@ -57,80 +53,6 @@ export function init($container, ver) {
             o10: "nowordssubstr",
             v10: "stalled,intermittent-failure",
         },
-    });
-
-    BugList.append({
-        id: `reo-${ver.name}-new-ni`,
-        $container: $container,
-        template: "needinfo",
-        title: `${ver.nightly} (${ver.title}) New Bugs With NEEDINFO`,
-        description:
-            "Bugs with all of the following:\n" +
-            "- regression keyword\n" +
-            `- status-firefox${ver.nightly} set to affected\n` +
-            `- status-firefox${ver.beta} set to any of unaffected ? ---\n` +
-            "- open NEEDINFO request\n" +
-            "Bugs with any of the following are ignored:\n" +
-            `- tracking-firefox${ver.nightly} is -\n` +
-            "- stalled or intermittent-failure keywords\n" +
-            "- within the Testing product\n" +
-            "Bugs are order by needinfo date, oldest first.",
-        query: {
-            classification: [
-                "Client Software",
-                "Components",
-                "Developer Infrastructure",
-                "Other",
-                "Server Software",
-            ],
-            keywords: "regression",
-            keywords_type: "allwords",
-            resolution: "---",
-            o1: "equals",
-            v1: "affected",
-            f1: `cf_status_firefox${ver.nightly}`,
-            j2: "OR",
-            f2: "OP",
-            f3: `cf_status_firefox${ver.beta}`,
-            o3: "equals",
-            v3: "unaffected",
-            f4: `cf_status_firefox${ver.beta}`,
-            o4: "equals",
-            v4: "?",
-            f5: `cf_status_firefox${ver.beta}`,
-            o5: "equals",
-            v5: "---",
-            f6: "CP",
-            f7: "flagtypes.name",
-            o7: "anywordssubstr",
-            v7: "needinfo",
-            f8: `cf_tracking_firefox${ver.nightly}`,
-            o8: "notequals",
-            v8: "-",
-            f9: "product",
-            o9: "notequals",
-            v9: "Testing",
-            f10: "keywords",
-            o10: "nowordssubstr",
-            v10: "stalled,intermittent-failure",
-        },
-        augment: (bug) => {
-            let nickSuffix = "";
-            let nameSuffix = "";
-            if (bug.needinfos[0].requestee === bug.triage_owner) {
-                nickSuffix = " (T)";
-                nameSuffix = " (Triage Owner)";
-            } else if (bug.needinfos[0].requestee === bug.creator) {
-                nickSuffix = " (R)";
-                nameSuffix = " (Reporter)";
-            }
-            bug.needinfo_nick = bug.needinfos[0].requestee_nick + nickSuffix;
-            bug.needinfo_name = bug.needinfos[0].requestee_name + nameSuffix;
-            bug.needinfo_date = bug.needinfos[0].date;
-            bug.needinfo_ago = bug.needinfos[0].ago;
-            bug.needinfo_epoch = bug.needinfos[0].epoch;
-        },
-        order: (a, b) => a.needinfo_epoch - b.needinfo_epoch,
     });
 
     BugList.append({
@@ -143,7 +65,6 @@ export function init($container, ver) {
             `- status-firefox${ver.nightly} set to affected\n` +
             "Bugs with any of the following are ignored:\n" +
             `- status-firefox${ver.beta} set to any of unaffected ? ---\n` +
-            "- open NEEDINFO request\n" +
             `- tracking-firefox${ver.nightly} is -\n` +
             "- stalled or intermittent-failure keywords\n" +
             "- within the Testing product\n" +
@@ -175,9 +96,6 @@ export function init($container, ver) {
             o5: "equals",
             v5: "---",
             f6: "CP",
-            o7: "notsubstring",
-            v7: "needinfo",
-            f7: "flagtypes.name",
             f8: `cf_tracking_firefox${ver.nightly}`,
             o8: "notequals",
             v8: "-",
@@ -194,84 +112,6 @@ export function init($container, ver) {
         order: (a, b) =>
             a.assigned_sortkey - b.assigned_sortkey ||
             a.updated_epoch - b.updated_epoch,
-    });
-
-    BugList.append({
-        id: `reo-${ver.name}-carryover-ni`,
-        $container: $container,
-        template: "needinfo",
-        title: `${ver.nightly} (${ver.title}) Carry Over Bugs With NEEDINFO`,
-        description:
-            "Bugs with all of the following:\n" +
-            "- regression keyword\n" +
-            `- status-firefox${ver.nightly} set to affected\n` +
-            "- open NEEDINFO request\n" +
-            "Bugs with any of the following are ignored:\n" +
-            `- status-firefox${ver.beta} set to any of unaffected ? ---\n` +
-            `- tracking-firefox${ver.nightly} is -\n` +
-            "- stalled or intermittent-failure keywords\n" +
-            "- within the Testing products\n" +
-            "Bugs are order by unassigned, then by needinfo date (oldest first)",
-        query: {
-            classification: [
-                "Client Software",
-                "Components",
-                "Developer Infrastructure",
-                "Other",
-                "Server Software",
-            ],
-            keywords: "regression",
-            keywords_type: "allwords",
-            resolution: "---",
-            f1: `cf_status_firefox${ver.nightly}`,
-            o1: "equals",
-            v1: "affected",
-            n2: "1",
-            j2: "OR",
-            f2: "OP",
-            f3: `cf_status_firefox${ver.beta}`,
-            o3: "equals",
-            v3: "unaffected",
-            f4: `cf_status_firefox${ver.beta}`,
-            o4: "equals",
-            v4: "?",
-            f5: `cf_status_firefox${ver.beta}`,
-            o5: "equals",
-            v5: "---",
-            f6: "CP",
-            o7: "anywordssubstr",
-            v7: "needinfo",
-            f7: "flagtypes.name",
-            f8: `cf_tracking_firefox${ver.nightly}`,
-            o8: "notequals",
-            v8: "-",
-            f9: "product",
-            o9: "notequals",
-            v9: "Testing",
-            f10: "keywords",
-            o10: "nowordssubstr",
-            v10: "stalled,intermittent-failure",
-        },
-        augment: (bug) => {
-            bug.assigned_sortkey = bug.assigned_to === "nobody@mozilla.org" ? 0 : 1;
-            let nickSuffix = "";
-            let nameSuffix = "";
-            if (bug.needinfos[0].requestee === bug.triage_owner) {
-                nickSuffix = " (T)";
-                nameSuffix = " (Triage Owner)";
-            } else if (bug.needinfos[0].requestee === bug.creator) {
-                nickSuffix = " (R)";
-                nameSuffix = " (Reporter)";
-            }
-            bug.needinfo_nick = bug.needinfos[0].requestee_nick + nickSuffix;
-            bug.needinfo_name = bug.needinfos[0].requestee_name + nameSuffix;
-            bug.needinfo_date = bug.needinfos[0].date;
-            bug.needinfo_ago = bug.needinfos[0].ago;
-            bug.needinfo_epoch = bug.needinfos[0].epoch;
-        },
-        order: (a, b) =>
-            a.assigned_sortkey - b.assigned_sortkey ||
-            a.needinfo_epoch - b.needinfo_epoch,
     });
 
     BugList.append({

--- a/app/buglists/reo.mjs
+++ b/app/buglists/reo.mjs
@@ -1,11 +1,109 @@
 import * as BugList from "buglist";
+import * as Bugzilla from "bugzilla";
+import * as Global from "global";
 
 /* eslint-disable camelcase */
+
+const g = {
+    // teams selected in the Regressions page team filter; empty = no filtering
+    teams: new Set(),
+};
+
+export function setTeams(teams) {
+    g.teams = new Set(teams);
+}
+
+function maxFieldNumber(query) {
+    return Math.max(
+        0,
+        ...Object.keys(query)
+            .filter((k) => /^f\d+$/.test(k))
+            .map((k) => Number(k.slice(1))),
+    );
+}
+
+// Restrict the query to components belonging to the selected teams. Components
+// are grouped by product; within each product a single `component anyexact`
+// matches the comma-free names, with an `equals` fallback for names that
+// themselves contain a comma (which anyexact would mis-split). This keeps the
+// generated URL compact enough to avoid Bugzilla's URL length limit.
+function appendTeamFilter(query) {
+    if (g.teams.size === 0) {
+        return;
+    }
+
+    const byProduct = new Map();
+    const productTotals = new Map();
+    for (const c of Global.allComponents()) {
+        productTotals.set(c.product, (productTotals.get(c.product) ?? 0) + 1);
+        if (!g.teams.has(c.team || "(none)")) {
+            continue;
+        }
+        if (!byProduct.has(c.product)) {
+            byProduct.set(c.product, []);
+        }
+        byProduct.get(c.product).push(c.component);
+    }
+    if (byProduct.size === 0) {
+        return;
+    }
+
+    let n = maxFieldNumber(query) + 1;
+    query[`f${n}`] = "OP";
+    query[`j${n}`] = "OR";
+    n++;
+    for (const [product, components] of byProduct) {
+        // When every component of a product is selected, matching on the product
+        // alone is equivalent and far shorter. Without this, selecting all teams
+        // enumerates every component and Bugzilla rejects the URL as too long.
+        if (components.length === productTotals.get(product)) {
+            query[`f${n}`] = "product";
+            query[`o${n}`] = "equals";
+            query[`v${n}`] = product;
+            n++;
+            continue;
+        }
+        query[`f${n}`] = "OP";
+        n++;
+        query[`f${n}`] = "product";
+        query[`o${n}`] = "equals";
+        query[`v${n}`] = product;
+        n++;
+        query[`f${n}`] = "OP";
+        query[`j${n}`] = "OR";
+        n++;
+        const safe = components.filter((c) => !c.includes(","));
+        if (safe.length > 0) {
+            query[`f${n}`] = "component";
+            query[`o${n}`] = "anyexact";
+            query[`v${n}`] = safe.join(",");
+            n++;
+        }
+        for (const c of components.filter((c) => c.includes(","))) {
+            query[`f${n}`] = "component";
+            query[`o${n}`] = "equals";
+            query[`v${n}`] = c;
+            n++;
+        }
+        query[`f${n}`] = "CP"; // close component sub-group
+        n++;
+        query[`f${n}`] = "CP"; // close product block
+        n++;
+    }
+    query[`f${n}`] = "CP"; // close team OR group
+}
+
+function reoUrlsBuilder(buglist) {
+    const query = { ...buglist.query };
+    appendTeamFilter(query);
+    return [Bugzilla.queryURL(query)];
+}
 
 export function init($container, ver) {
     BugList.append({
         id: `reo-${ver.name}-new`,
         $container: $container,
+        urlsBuilder: reoUrlsBuilder,
         title: `${ver.nightly} (${ver.title}) New Bugs`,
         description:
             "Bugs with all of the following:\n" +
@@ -58,6 +156,7 @@ export function init($container, ver) {
     BugList.append({
         id: `reo-${ver.name}-carryover`,
         $container: $container,
+        urlsBuilder: reoUrlsBuilder,
         title: `${ver.nightly} (${ver.title}) Carry Over Bugs`,
         description:
             "Bugs with all of the following:\n" +
@@ -117,6 +216,7 @@ export function init($container, ver) {
     BugList.append({
         id: `reo-${ver.name}-burndown`,
         $container: $container,
+        urlsBuilder: reoUrlsBuilder,
         title: `${ver.nightly} (${ver.title}) Burndown List`,
         description:
             "Bugs with all of the following:\n" +

--- a/app/tabs/reo.css
+++ b/app/tabs/reo.css
@@ -1,0 +1,57 @@
+/* Regressions team filter — minimal functional styling only */
+
+#reo-teams {
+    margin-bottom: 1em;
+}
+
+/* Fixed rather than content-sized: the longest team name is close to tippy's
+   default max width, so an auto width visibly reflowed whenever the selection
+   count changed length. 24em fits the longest name without truncating it, and
+   leaves the button row room to stay on one line. */
+#reo-teams-popover {
+    width: 24em;
+}
+
+#reo-teams-search {
+    box-sizing: border-box;
+    width: 100%;
+    margin-bottom: 0.5em;
+}
+
+#reo-teams-list {
+    max-height: 16em;
+    overflow-y: auto;
+}
+
+.reo-teams-row {
+    display: flex;
+    gap: 0.4em;
+    align-items: center;
+    white-space: nowrap;
+}
+
+/* ellipsis rather than overflow, should a team name ever outgrow the popover */
+.reo-teams-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* own line, so its changing text can't reflow the button row */
+#reo-teams-count {
+    margin-top: 0.5em;
+    white-space: nowrap;
+}
+
+#reo-teams-actions {
+    display: flex;
+    gap: 0.5em;
+    align-items: center;
+    margin-top: 0.5em;
+}
+
+/* Apply commits; the select all/none pair only stages. Pushing Apply to the
+   trailing edge separates the two groups and keeps it in the primary position. */
+#reo-teams-apply {
+    margin-left: auto;
+}

--- a/app/tabs/reo.css
+++ b/app/tabs/reo.css
@@ -1,4 +1,12 @@
-/* Regressions team filter — minimal functional styling only */
+/* Regressions page filters — minimal functional styling only */
+
+/* Holds one line whether or not it has text, so showing or clearing the active
+   filter summary doesn't shift everything below it. line-height is set here
+   rather than inherited so min-height matches the rendered line exactly. */
+#reo-filters-active {
+    min-height: 1.3em;
+    line-height: 1.3;
+}
 
 #reo-teams {
     margin-bottom: 1em;

--- a/app/tabs/reo.mjs
+++ b/app/tabs/reo.mjs
@@ -9,11 +9,11 @@ export function initUI() {
     const releases = Global.releaseData();
     const versions = [
         {
-            name: "nightly",
-            title: "Nightly",
-            release: releases.release.version,
-            beta: releases.beta.version,
-            nightly: releases.nightly.version,
+            name: "release",
+            title: "Release",
+            release: releases.release.version - 2,
+            beta: releases.beta.version - 2,
+            nightly: releases.nightly.version - 2,
         },
         {
             name: "beta",
@@ -23,11 +23,11 @@ export function initUI() {
             nightly: releases.nightly.version - 1,
         },
         {
-            name: "release",
-            title: "Release",
-            release: releases.release.version - 2,
-            beta: releases.beta.version - 2,
-            nightly: releases.nightly.version - 2,
+            name: "nightly",
+            title: "Nightly",
+            release: releases.release.version,
+            beta: releases.beta.version,
+            nightly: releases.nightly.version,
         },
     ];
 

--- a/app/tabs/reo.mjs
+++ b/app/tabs/reo.mjs
@@ -1,10 +1,204 @@
 import * as BugList from "buglist";
 import * as REO from "buglists/reo";
 import * as Global from "global";
-import { _ } from "util";
+import * as Tooltips from "tooltips";
+import { _, __, cloneTemplate } from "util";
+
+/* global tippy */
+
+const g = {
+    // teams filter: applied set, popover node, and its tippy instance
+    appliedTeams: new Set(),
+    $popover: undefined,
+    tip: undefined,
+};
+
+function refreshLists() {
+    for (const $buglist of __("#reo-content .buglist-container")) {
+        BugList.updateQuery($buglist.id);
+    }
+}
+
+// unique team names from the loaded Bugzilla components, sorted alphabetically
+// with the "(none)" bucket last
+function allTeams() {
+    const teams = new Set();
+    for (const c of Global.allComponents()) {
+        teams.add(c.team || "(none)");
+    }
+    return [...teams].sort((a, b) => {
+        if (a === "(none)") return 1;
+        if (b === "(none)") return -1;
+        return a.localeCompare(b);
+    });
+}
+
+function checkedTeams() {
+    return new Set([...__(g.$popover, "input:checked")].map(($cb) => $cb.value));
+}
+
+function sameSet(a, b) {
+    return a.size === b.size && [...a].every((x) => b.has(x));
+}
+
+// the team rows the search box currently leaves visible
+function visibleTeamRows() {
+    return [...__(g.$popover, ".reo-teams-row")].filter(
+        ($row) => !$row.classList.contains("hidden"),
+    );
+}
+
+function updateTeamsButtons() {
+    const checked = checkedTeams();
+    const rows = visibleTeamRows();
+    const total = __(g.$popover, ".reo-teams-row").length;
+
+    _(g.$popover, "#reo-teams-apply").disabled = sameSet(checked, g.appliedTeams);
+    // "Select none" only unchecks; Apply remains the single point that commits,
+    // so this is meaningful whenever something is checked.
+    _(g.$popover, "#reo-teams-select-none").disabled = checked.size === 0;
+    // "Select all" acts on the rows the search shows, so it's only meaningful
+    // while one of those is still unchecked. Naming the count once a search has
+    // narrowed the list makes it obvious the hidden rows are left alone.
+    const $selectAll = _(g.$popover, "#reo-teams-select-all");
+    $selectAll.disabled =
+        rows.length === 0 || rows.every(($row) => _($row, "input").checked);
+    $selectAll.textContent =
+        rows.length < total ? `Select all ${rows.length}` : "Select all";
+    // staged selection count; the button label shows the applied count
+    _(g.$popover, "#reo-teams-count").textContent =
+        checked.size > 0 ? `${checked.size} selected` : "None selected";
+}
+
+function updateTeamsButton() {
+    const $label = _("#reo-teams-label");
+    $label.textContent =
+        g.appliedTeams.size > 0
+            ? `Filter by teams (${g.appliedTeams.size})`
+            : "Filter by teams";
+    // hover shows which teams are applied (or the filter's purpose when none).
+    // Attached to the label span, not the button, so it doesn't clobber the
+    // button's click-popover tippy instance.
+    Tooltips.set(
+        $label,
+        g.appliedTeams.size > 0
+            ? [...g.appliedTeams].sort().join("\n")
+            : "Filter all lists by team",
+    );
+}
+
+function applyTeams() {
+    g.appliedTeams = checkedTeams();
+    REO.setTeams(g.appliedTeams);
+    refreshLists();
+    saveTeamsToURL();
+    updateTeamsButton();
+    updateTeamsButtons();
+}
+
+function saveTeamsToURL() {
+    const url = new URL(window.location.href);
+    url.searchParams.delete("reoteam");
+    for (const team of g.appliedTeams) {
+        url.searchParams.append("reoteam", team);
+    }
+    if (url.href.length < 2048) {
+        window.history.replaceState(undefined, undefined, url.href);
+    }
+}
+
+// restore the applied teams from the URL, ignoring any that no longer exist
+function loadTeamsFromURL() {
+    const known = new Set(allTeams());
+    const teams = new URLSearchParams(window.location.search)
+        .getAll("reoteam")
+        .filter((team) => known.has(team));
+    g.appliedTeams = new Set(teams);
+    for (const $cb of __(g.$popover, "input")) {
+        $cb.checked = g.appliedTeams.has($cb.value);
+    }
+    REO.setTeams(g.appliedTeams);
+    updateTeamsButton();
+    updateTeamsButtons();
+}
+
+function buildPopover() {
+    g.$popover = cloneTemplate(_("#reo-teams-popover-template")).firstElementChild;
+
+    // one row per team
+    const $list = _(g.$popover, "#reo-teams-list");
+    for (const team of allTeams()) {
+        const $row = cloneTemplate(_("#reo-teams-row-template")).firstElementChild;
+        _($row, "input").value = team;
+        _($row, ".reo-teams-name").textContent = team;
+        $list.append($row);
+    }
+
+    _(g.$popover, "#reo-teams-list").addEventListener("change", updateTeamsButtons);
+    _(g.$popover, "#reo-teams-search").addEventListener("input", (event) => {
+        const query = event.target.value.trim().toLowerCase();
+        for (const $row of __(g.$popover, ".reo-teams-row")) {
+            const name = _($row, ".reo-teams-name").textContent.toLowerCase();
+            $row.classList.toggle("hidden", query !== "" && !name.includes(query));
+        }
+        // "Select all" tracks the rows the search leaves visible
+        updateTeamsButtons();
+    });
+    _(g.$popover, "#reo-teams-select-all").addEventListener("click", () => {
+        for (const $row of visibleTeamRows()) {
+            _($row, "input").checked = true;
+        }
+        updateTeamsButtons();
+    });
+    // "Select none" stages a full deselection rather than committing it, so it
+    // mirrors "Select all" and can't silently discard an applied filter.
+    _(g.$popover, "#reo-teams-select-none").addEventListener("click", () => {
+        for (const $cb of __(g.$popover, "input:checked")) {
+            $cb.checked = false;
+        }
+        updateTeamsButtons();
+    });
+    _(g.$popover, "#reo-teams-apply").addEventListener("click", () => {
+        applyTeams();
+        g.tip.hide();
+    });
+}
 
 export function initUI() {
     const $content = _("#reo-content");
+
+    // teams filter
+    $content.append(cloneTemplate(_("#reo-teams-template")).firstElementChild);
+    buildPopover();
+    g.tip = tippy(_("#reo-teams-button"), {
+        trigger: "click",
+        interactive: true,
+        arrow: false,
+        placement: "bottom-start",
+        appendTo: () => document.body,
+        // the popover sets its own width; tippy's 350px default would clamp it
+        maxWidth: "none",
+        content: g.$popover,
+        onShow() {
+            // reset any prior search so the full list shows on reopen
+            _(g.$popover, "#reo-teams-search").value = "";
+            for (const $row of __(g.$popover, ".reo-teams-row")) {
+                $row.classList.remove("hidden");
+            }
+            // reflect the applied state
+            for (const $cb of __(g.$popover, "input")) {
+                $cb.checked = g.appliedTeams.has($cb.value);
+            }
+            updateTeamsButtons();
+        },
+        onShown() {
+            // let the user start typing to filter teams immediately
+            _(g.$popover, "#reo-teams-search").focus();
+        },
+    });
+
+    // restore any teams persisted in the URL (before the lists first fetch)
+    loadTeamsFromURL();
 
     const releases = Global.releaseData();
     const versions = [

--- a/app/tabs/reo.mjs
+++ b/app/tabs/reo.mjs
@@ -6,7 +6,29 @@ import { _, __, cloneTemplate } from "util";
 
 /* global tippy */
 
+const FILTER_DEFS = [
+    { id: "reo-filter-severity-high", key: "severityHigh", label: "Severity S2+" },
+    {
+        id: "reo-filter-missing-severity",
+        key: "missingSeverity",
+        label: "Missing severity",
+    },
+    { id: "reo-filter-unassigned", key: "unassigned", label: "Unassigned" },
+    {
+        id: "reo-filter-missing-regressor",
+        key: "missingRegressor",
+        label: "Missing regressor",
+    },
+    {
+        id: "reo-filter-without-needinfo",
+        key: "withoutNeedinfo",
+        label: "Without NEEDINFO",
+    },
+];
+
 const g = {
+    // quick filters: last-applied state (for dirty detection)
+    appliedFilters: Object.fromEntries(FILTER_DEFS.map((d) => [d.key, false])),
     // teams filter: applied set, popover node, and its tippy instance
     appliedTeams: new Set(),
     $popover: undefined,
@@ -18,6 +40,43 @@ function refreshLists() {
         BugList.updateQuery($buglist.id);
     }
 }
+
+/* ---- quick filters ---- */
+
+function checkedFilters() {
+    return Object.fromEntries(FILTER_DEFS.map((d) => [d.key, _(`#${d.id}`).checked]));
+}
+
+function updateFilterButtons() {
+    const checked = checkedFilters();
+    const dirty = FILTER_DEFS.some((d) => checked[d.key] !== g.appliedFilters[d.key]);
+    const anyChecked = Object.values(checked).some(Boolean);
+    const anyApplied = Object.values(g.appliedFilters).some(Boolean);
+    // Apply is only meaningful when the checkboxes differ from what's applied.
+    _("#reo-filter-apply").disabled = !dirty;
+    // Clear is only meaningful when there's something to clear.
+    _("#reo-filter-clear").disabled = !anyChecked && !anyApplied;
+}
+
+// Empty when nothing is applied; the element keeps its height either way (see
+// reo.css), so applying or clearing a filter can't shift the page below it.
+function updateFilterIndicator() {
+    const active = FILTER_DEFS.filter((d) => g.appliedFilters[d.key]);
+    _("#reo-filters-active").textContent =
+        active.length > 0
+            ? `Filtering: ${active.map((d) => d.label).join(" OR ")}`
+            : "";
+}
+
+function applyFilters() {
+    g.appliedFilters = checkedFilters();
+    REO.setFilters(g.appliedFilters);
+    refreshLists();
+    updateFilterIndicator();
+    updateFilterButtons();
+}
+
+/* ---- teams filter ---- */
 
 // unique team names from the loaded Bugzilla components, sorted alphabetically
 // with the "(none)" bucket last
@@ -166,6 +225,20 @@ function buildPopover() {
 
 export function initUI() {
     const $content = _("#reo-content");
+
+    // quick filter bar
+    $content.append(cloneTemplate(_("#reo-filters-template")).firstElementChild);
+    for (const def of FILTER_DEFS) {
+        _(`#${def.id}`).addEventListener("change", updateFilterButtons);
+    }
+    _("#reo-filter-apply").addEventListener("click", applyFilters);
+    _("#reo-filter-clear").addEventListener("click", () => {
+        for (const def of FILTER_DEFS) {
+            _(`#${def.id}`).checked = false;
+        }
+        applyFilters();
+    });
+    updateFilterButtons();
 
     // teams filter
     $content.append(cloneTemplate(_("#reo-teams-template")).firstElementChild);

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
       type="text/css"
       href="app/tabs/help.css?c85e68301e2f59a3727b7f4884e85d71"
     >
+    <link rel="stylesheet" type="text/css" href="app/tabs/reo.css?3e80db09d6d99efd8c5081b12a174568">
     <link rel="stylesheet" type="text/css" href="app/buglist.css?891552c0f470b4c59dc67f942d33b057">
     <link rel="stylesheet" type="text/css" href="app/bugtable.css?5d4ebc21b4656580d6e28319d737ebe3">
     <link rel="stylesheet" type="text/css" href="app/dialog.css?ac7e56024618ca7d27da454c08c7b17e">
@@ -54,7 +55,7 @@
         "buglists/recent-regressions": "./app/buglists/recent-regressions.mjs?cc6ff2953e2dbafabf00374136e09fc4",
         "buglists/recent-tasks": "./app/buglists/recent-tasks.mjs?e3a0aafb44daa5887a92b7dc01ce644e",
         "buglists/regressions": "./app/buglists/regressions.mjs?5bbbf6bfd80a2ee635a87f95f40e6bd9",
-        "buglists/reo": "./app/buglists/reo.mjs?7b1f46b631671862e657c75a3466f97b",
+        "buglists/reo": "./app/buglists/reo.mjs?3eb3073e357f3209dca4e6c7bf84e37b",
         "buglists/security": "./app/buglists/security.mjs?58f16e488e6bc6293b9577078dd9deb4",
         "buglists/stalled": "./app/buglists/stalled.mjs?da2d4f814ac5b70c90a3ebb32f3b23e6",
         "buglists/topcrashers": "./app/buglists/topcrashers.mjs?b747f1889a13ac5127212473cf75fc78",
@@ -72,7 +73,7 @@
         "tabs/help": "./app/tabs/help.mjs?61201f8aedc7ee3a1827b596237a9466",
         "tabs/important": "./app/tabs/important.mjs?f824d7e360e756bb8de02c24c01831f9",
         "tabs/overview": "./app/tabs/overview.mjs?a3a226d77b36255540f08a03fbf8b0b9",
-        "tabs/reo": "./app/tabs/reo.mjs?a5d489d2f9012bba5bf1847eab4b879f",
+        "tabs/reo": "./app/tabs/reo.mjs?ae4d66baf7dcba4dd7a894f6c899c117",
         "tabs/stalled": "./app/tabs/stalled.mjs?35ad2cb4ab092aef77c455daca511acb",
         "tabs/tracked": "./app/tabs/tracked.mjs?2c240c3e7d979a69693812392f2029d2",
         "tabs/triage": "./app/tabs/triage.mjs?deb37c0fc8702feee793c3d776fae4f2",
@@ -260,6 +261,31 @@
       <div data-id-field="outer" class="content">
         <div data-id-field="inner"></div>
       </div>
+    </template>
+
+    <!-- template: reo team filter -->
+    <template id="reo-teams-template">
+      <div id="reo-teams">
+        <button id="reo-teams-button"><span id="reo-teams-label">Filter by teams</span> ▾</button>
+      </div>
+    </template>
+    <template id="reo-teams-popover-template">
+      <div id="reo-teams-popover">
+        <input type="search" id="reo-teams-search" placeholder="Search teams…">
+        <div id="reo-teams-list"></div>
+        <div id="reo-teams-count">None selected</div>
+        <div id="reo-teams-actions">
+          <button id="reo-teams-select-all">Select all</button>
+          <button id="reo-teams-select-none" disabled>Select none</button>
+          <button id="reo-teams-apply" disabled>Apply</button>
+        </div>
+      </div>
+    </template>
+    <template id="reo-teams-row-template">
+      <label class="reo-teams-row">
+        <input type="checkbox">
+        <span class="reo-teams-name"></span>
+      </label>
     </template>
 
     <!-- template: buglist group -->

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
         "buglists/recent-regressions": "./app/buglists/recent-regressions.mjs?cc6ff2953e2dbafabf00374136e09fc4",
         "buglists/recent-tasks": "./app/buglists/recent-tasks.mjs?e3a0aafb44daa5887a92b7dc01ce644e",
         "buglists/regressions": "./app/buglists/regressions.mjs?5bbbf6bfd80a2ee635a87f95f40e6bd9",
-        "buglists/reo": "./app/buglists/reo.mjs?cea7533c254b4f1758ee030c75b4beb8",
+        "buglists/reo": "./app/buglists/reo.mjs?7b1f46b631671862e657c75a3466f97b",
         "buglists/security": "./app/buglists/security.mjs?58f16e488e6bc6293b9577078dd9deb4",
         "buglists/stalled": "./app/buglists/stalled.mjs?da2d4f814ac5b70c90a3ebb32f3b23e6",
         "buglists/topcrashers": "./app/buglists/topcrashers.mjs?b747f1889a13ac5127212473cf75fc78",

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
         "tabs/help": "./app/tabs/help.mjs?61201f8aedc7ee3a1827b596237a9466",
         "tabs/important": "./app/tabs/important.mjs?f824d7e360e756bb8de02c24c01831f9",
         "tabs/overview": "./app/tabs/overview.mjs?a3a226d77b36255540f08a03fbf8b0b9",
-        "tabs/reo": "./app/tabs/reo.mjs?7de1da35f46e4afe6de0d35488b3768f",
+        "tabs/reo": "./app/tabs/reo.mjs?a5d489d2f9012bba5bf1847eab4b879f",
         "tabs/stalled": "./app/tabs/stalled.mjs?35ad2cb4ab092aef77c455daca511acb",
         "tabs/tracked": "./app/tabs/tracked.mjs?2c240c3e7d979a69693812392f2029d2",
         "tabs/triage": "./app/tabs/triage.mjs?deb37c0fc8702feee793c3d776fae4f2",

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       type="text/css"
       href="app/tabs/help.css?c85e68301e2f59a3727b7f4884e85d71"
     >
-    <link rel="stylesheet" type="text/css" href="app/tabs/reo.css?3e80db09d6d99efd8c5081b12a174568">
+    <link rel="stylesheet" type="text/css" href="app/tabs/reo.css?5f385d9b9e4825da44419fe02aae4f6f">
     <link rel="stylesheet" type="text/css" href="app/buglist.css?891552c0f470b4c59dc67f942d33b057">
     <link rel="stylesheet" type="text/css" href="app/bugtable.css?5d4ebc21b4656580d6e28319d737ebe3">
     <link rel="stylesheet" type="text/css" href="app/dialog.css?ac7e56024618ca7d27da454c08c7b17e">
@@ -55,7 +55,7 @@
         "buglists/recent-regressions": "./app/buglists/recent-regressions.mjs?cc6ff2953e2dbafabf00374136e09fc4",
         "buglists/recent-tasks": "./app/buglists/recent-tasks.mjs?e3a0aafb44daa5887a92b7dc01ce644e",
         "buglists/regressions": "./app/buglists/regressions.mjs?5bbbf6bfd80a2ee635a87f95f40e6bd9",
-        "buglists/reo": "./app/buglists/reo.mjs?3eb3073e357f3209dca4e6c7bf84e37b",
+        "buglists/reo": "./app/buglists/reo.mjs?eeb98b99bc630696cb8c3bf02d28ba02",
         "buglists/security": "./app/buglists/security.mjs?58f16e488e6bc6293b9577078dd9deb4",
         "buglists/stalled": "./app/buglists/stalled.mjs?da2d4f814ac5b70c90a3ebb32f3b23e6",
         "buglists/topcrashers": "./app/buglists/topcrashers.mjs?b747f1889a13ac5127212473cf75fc78",
@@ -73,7 +73,7 @@
         "tabs/help": "./app/tabs/help.mjs?61201f8aedc7ee3a1827b596237a9466",
         "tabs/important": "./app/tabs/important.mjs?f824d7e360e756bb8de02c24c01831f9",
         "tabs/overview": "./app/tabs/overview.mjs?a3a226d77b36255540f08a03fbf8b0b9",
-        "tabs/reo": "./app/tabs/reo.mjs?ae4d66baf7dcba4dd7a894f6c899c117",
+        "tabs/reo": "./app/tabs/reo.mjs?67f9cc3a2a852018030b9d2b33651fb8",
         "tabs/stalled": "./app/tabs/stalled.mjs?35ad2cb4ab092aef77c455daca511acb",
         "tabs/tracked": "./app/tabs/tracked.mjs?2c240c3e7d979a69693812392f2029d2",
         "tabs/triage": "./app/tabs/triage.mjs?deb37c0fc8702feee793c3d776fae4f2",
@@ -260,6 +260,30 @@
     <template id="tab-content-template">
       <div data-id-field="outer" class="content">
         <div data-id-field="inner"></div>
+      </div>
+    </template>
+
+    <!-- template: reo quick filters -->
+    <template id="reo-filters-template">
+      <div id="reo-filters">
+        <span class="reo-filters-label">Show bugs in all lists matching any of:</span>
+        <input type="checkbox" id="reo-filter-severity-high">
+        <label for="reo-filter-severity-high">Severity S2+</label>
+        <span class="reo-filters-or">or</span>
+        <input type="checkbox" id="reo-filter-missing-severity">
+        <label for="reo-filter-missing-severity">Missing severity</label>
+        <span class="reo-filters-or">or</span>
+        <input type="checkbox" id="reo-filter-unassigned">
+        <label for="reo-filter-unassigned">Unassigned</label>
+        <span class="reo-filters-or">or</span>
+        <input type="checkbox" id="reo-filter-missing-regressor">
+        <label for="reo-filter-missing-regressor">Missing regressor</label>
+        <span class="reo-filters-or">or</span>
+        <input type="checkbox" id="reo-filter-without-needinfo">
+        <label for="reo-filter-without-needinfo">Without NEEDINFO</label>
+        <button id="reo-filter-apply" disabled>Apply</button>
+        <button id="reo-filter-clear" disabled>Clear</button>
+        <div id="reo-filters-active"></div>
       </div>
     </template>
 


### PR DESCRIPTION
Some improvements to the Regressions (reo) page: two query cleanups, then two
filters for narrowing every query on the page at once.

- **Reorder the reo regressions lists to Release, Beta, Nightly** — presents the
  three version groups in release-channel order.
- **Combine the NEEDINFO reo lists into their parent lists** — drops the separate
  NEEDINFO lists, folding those bugs into the list they belong to.
- **Add a Teams filter** — a searchable popover of Bugzilla component teams with
  Select all / Select none, staged behind Apply, applied to every list on the
  page and persisted in the URL so a filtered view can be shared.
- **Add quick filters** — a checkbox bar (Severity S2+, Missing severity,
  Unassigned, Missing regressor, Without NEEDINFO). When any are checked, each
  list keeps bugs matching ANY of them, with an active-filter summary line.